### PR TITLE
Fixed layout height issues on N

### DIFF
--- a/library/src/main/java/com/raizlabs/freshair/WrapContentHeightViewPager.java
+++ b/library/src/main/java/com/raizlabs/freshair/WrapContentHeightViewPager.java
@@ -18,20 +18,30 @@ class WrapContentHeightViewPager extends ViewPager {
     @Override
     protected void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
 
-        int height = 0;
-        for (int i = 0; i < getChildCount(); i++) {
-            View child = getChildAt(i);
+        int mode = MeasureSpec.getMode(heightMeasureSpec);
 
-            child.measure(widthMeasureSpec, MeasureSpec.makeMeasureSpec(0, MeasureSpec.UNSPECIFIED));
+        if (mode == MeasureSpec.UNSPECIFIED || mode == MeasureSpec.AT_MOST) {
+            // Has to be called so child views can be initialized
+            super.onMeasure(widthMeasureSpec, heightMeasureSpec);
 
-            int h = child.getMeasuredHeight();
+            int height = 0;
 
-            if (h > height) {
-                height = h;
+            for (int i = 0; i < getChildCount(); i++) {
+                View child = getChildAt(i);
+
+                child.measure(widthMeasureSpec, MeasureSpec.makeMeasureSpec(0, MeasureSpec.UNSPECIFIED));
+
+                int h = child.getMeasuredHeight();
+
+                if (h > height) {
+                    height = h;
+                }
             }
+
+            heightMeasureSpec = MeasureSpec.makeMeasureSpec(height, MeasureSpec.EXACTLY);
         }
 
-        heightMeasureSpec = MeasureSpec.makeMeasureSpec(height, MeasureSpec.EXACTLY);
+        // Has to be called again so the new specs are treated as exact measurements
         super.onMeasure(widthMeasureSpec, heightMeasureSpec);
     }
 }


### PR DESCRIPTION
The `onMeasure` was only being called once before the child views were initialized, resulting in a malformed dialog because the `WrapContentHeightViewPager` height was not properly measured.
